### PR TITLE
Fix numerous exporting bugs

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,6 +81,9 @@ dependencies {
     implementation "org.jetbrains.anko:anko-design:$ankoVersion"
     implementation "org.jetbrains.anko:anko-appcompat-v7-commons:$ankoVersion"
 
+    implementation 'io.reactivex.rxjava2:rxjava:2.1.6'
+    implementation 'io.reactivex.rxjava2:rxandroid:2.0.1'
+
     // Support libraries
     implementation 'com.android.support:multidex:1.0.2'
     implementation "com.android.support:design:$supportLibVersion"

--- a/app/src/main/java/com/supercilex/robotscouter/data/client/spreadsheet/ExportNotificationManager.kt
+++ b/app/src/main/java/com/supercilex/robotscouter/data/client/spreadsheet/ExportNotificationManager.kt
@@ -72,6 +72,7 @@ class ExportNotificationManager(private val service: ExportService) {
                 .groupBy { it.first }
                 .flatMap {
                     it.sample(
+                            // Multiply to ensure the overall rate limitation
                             SAFE_NOTIFICATION_RATE_LIMIT_IN_MILLIS * nTemplates,
                             TimeUnit.MILLISECONDS,
                             true)
@@ -154,9 +155,8 @@ class ExportNotificationManager(private val service: ExportService) {
     }
 
     fun abort() {
+        for ((_, holder) in exporters) notificationManager.cancel(holder.id)
         ServiceCompat.stopForeground(service, ServiceCompat.STOP_FOREGROUND_REMOVE)
-        notificationManager.cancel(hashCode())
-        for (exporter in exporters) notificationManager.cancel(exporter.value.id)
     }
 
     private fun next(exporter: SpreadsheetExporter, notification: NotificationCompat.Builder) {

--- a/app/src/main/java/com/supercilex/robotscouter/data/client/spreadsheet/ExportNotificationManager.kt
+++ b/app/src/main/java/com/supercilex/robotscouter/data/client/spreadsheet/ExportNotificationManager.kt
@@ -22,23 +22,21 @@ import kotlin.properties.Delegates
 class ExportNotificationManager(private val service: ExportService) {
     private val notificationPublisher = PublishSubject.create<Pair<Int, Notification>>()
 
-    private val masterNotification: NotificationCompat.Builder
-        get() = NotificationCompat.Builder(
-                RobotScouter.INSTANCE, EXPORT_IN_PROGRESS_CHANNEL)
-                .setGroup(hashCode().toString())
-                .setGroupSummary(true)
-                .setContentTitle(RobotScouter.INSTANCE.getString(R.string.export_overall_progress_title))
-                .setColor(ContextCompat.getColor(RobotScouter.INSTANCE, R.color.colorPrimary))
-                .setPriority(NotificationCompat.PRIORITY_LOW)
-    private val exportNotification: NotificationCompat.Builder
-        get() = NotificationCompat.Builder(
-                RobotScouter.INSTANCE, EXPORT_IN_PROGRESS_CHANNEL)
-                .setGroup(hashCode().toString())
-                .setContentTitle(RobotScouter.INSTANCE.getString(R.string.export_progress_title))
-                .setSmallIcon(android.R.drawable.stat_sys_upload)
-                .setColor(ContextCompat.getColor(RobotScouter.INSTANCE, R.color.colorPrimary))
-                .setOngoing(true)
-                .setPriority(NotificationCompat.PRIORITY_LOW)
+    private val masterNotification: NotificationCompat.Builder get() = NotificationCompat.Builder(
+            RobotScouter.INSTANCE, EXPORT_IN_PROGRESS_CHANNEL)
+            .setGroup(hashCode().toString())
+            .setGroupSummary(true)
+            .setContentTitle(RobotScouter.INSTANCE.getString(R.string.export_overall_progress_title))
+            .setColor(ContextCompat.getColor(RobotScouter.INSTANCE, R.color.colorPrimary))
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+    private val exportNotification: NotificationCompat.Builder get() = NotificationCompat.Builder(
+            RobotScouter.INSTANCE, EXPORT_IN_PROGRESS_CHANNEL)
+            .setGroup(hashCode().toString())
+            .setContentTitle(RobotScouter.INSTANCE.getString(R.string.export_progress_title))
+            .setSmallIcon(android.R.drawable.stat_sys_upload)
+            .setColor(ContextCompat.getColor(RobotScouter.INSTANCE, R.color.colorPrimary))
+            .setOngoing(true)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
 
     private val masterNotificationHolder = MasterNotificationHolder()
     private val exporters = ConcurrentHashMap<SpreadsheetExporter, NotificationHolder>()
@@ -111,17 +109,14 @@ class ExportNotificationManager(private val service: ExportService) {
         return id
     }
 
-    @Synchronized
     fun updateProgress(exporter: SpreadsheetExporter, team: Team) =
             next(exporter, exportNotification.setContentText(team.toString()))
 
-    @Synchronized
     fun onStartBuildingAverageSheet(exporter: SpreadsheetExporter) {
         next(exporter, exportNotification
                 .setContentText(RobotScouter.INSTANCE.getString(R.string.export_average_status)))
     }
 
-    @Synchronized
     fun onStartCleanup(exporter: SpreadsheetExporter) {
         next(exporter, exportNotification
                 .setContentText(RobotScouter.INSTANCE.getString(R.string.export_cleanup_status)))

--- a/app/src/main/java/com/supercilex/robotscouter/data/client/spreadsheet/ExportService.kt
+++ b/app/src/main/java/com/supercilex/robotscouter/data/client/spreadsheet/ExportService.kt
@@ -62,9 +62,7 @@ class ExportService : IntentService(TAG) {
         val templateNames = getTemplateNames(zippedScouts.keys)
         Tasks.await(Tasks.whenAll(zippedScouts.map { (templateId, scouts) ->
             async {
-                SpreadsheetExporter(scouts,
-                                    notificationManager,
-                                    templateNames[templateId]!!)
+                SpreadsheetExporter(scouts, notificationManager, templateNames[templateId]!!)
                         .export()
             }.addOnFailureListener {
                 abortCritical(it, notificationManager)
@@ -87,6 +85,7 @@ class ExportService : IntentService(TAG) {
 
         val usedTemplates = HashMap<String, Int>()
         return templateIds.associate {
+            // Getting the name will be null if the user deletes a template
             it to (allPossibleTemplateNames[it] ?: unknownTemplateName)
         }.mapValues { (_, name) ->
             usedTemplates[name]?.let {

--- a/app/src/main/java/com/supercilex/robotscouter/data/client/spreadsheet/ExportService.kt
+++ b/app/src/main/java/com/supercilex/robotscouter/data/client/spreadsheet/ExportService.kt
@@ -57,7 +57,7 @@ class ExportService : IntentService(TAG) {
                                newScouts: Map<Team, List<Scout>>) {
         val zippedScouts = zipScouts(newScouts)
 
-        notificationManager.setNumOfTemplates(zippedScouts.size)
+        notificationManager.setData(zippedScouts.size, newScouts.keys)
 
         val templateNames = getTemplateNames(zippedScouts.keys)
         Tasks.await(Tasks.whenAll(zippedScouts.map { (templateId, scouts) ->

--- a/app/src/main/java/com/supercilex/robotscouter/data/client/spreadsheet/ExportService.kt
+++ b/app/src/main/java/com/supercilex/robotscouter/data/client/spreadsheet/ExportService.kt
@@ -7,7 +7,9 @@ import android.support.annotation.RequiresPermission
 import android.support.annotation.Size
 import android.support.v4.app.Fragment
 import android.support.v4.content.ContextCompat
+import com.crashlytics.android.Crashlytics
 import com.google.android.gms.tasks.Tasks
+import com.google.firebase.crash.FirebaseCrash
 import com.supercilex.robotscouter.R
 import com.supercilex.robotscouter.data.model.Scout
 import com.supercilex.robotscouter.data.model.Team
@@ -15,17 +17,18 @@ import com.supercilex.robotscouter.data.model.TemplateType
 import com.supercilex.robotscouter.util.async
 import com.supercilex.robotscouter.util.data.getTeamListExtra
 import com.supercilex.robotscouter.util.data.model.getScouts
-import com.supercilex.robotscouter.util.data.model.getTemplateName
 import com.supercilex.robotscouter.util.data.model.getTemplatesQuery
 import com.supercilex.robotscouter.util.data.putExtra
 import com.supercilex.robotscouter.util.data.scoutParser
 import com.supercilex.robotscouter.util.isOffline
 import com.supercilex.robotscouter.util.logExportTeamsEvent
+import com.supercilex.robotscouter.util.logFailures
 import com.supercilex.robotscouter.util.ui.PermissionRequestHandler
 import org.apache.poi.ss.formula.WorkbookEvaluator
 import org.jetbrains.anko.design.snackbar
 import org.jetbrains.anko.intentFor
 import pub.devrel.easypermissions.EasyPermissions
+import java.util.concurrent.TimeUnit
 
 class ExportService : IntentService(TAG) {
     init {
@@ -41,7 +44,7 @@ class ExportService : IntentService(TAG) {
         val teams = intent.getTeamListExtra()
         try {
             val scoutTasks = teams.map { it.getScouts() }
-            Tasks.await(Tasks.whenAll(scoutTasks))
+            Tasks.await(Tasks.whenAll(scoutTasks), TIMEOUT, TimeUnit.MINUTES)
             onHandleScouts(
                     notificationManager,
                     scoutTasks.withIndex().associate { teams[it.index] to it.value.result })
@@ -56,22 +59,44 @@ class ExportService : IntentService(TAG) {
 
         notificationManager.setNumOfTemplates(zippedScouts.size)
 
-        val templates = Tasks.await(getTemplatesQuery().get())
-                .map { scoutParser.parseSnapshot(it) }
+        val templateNames = getTemplateNames(zippedScouts.keys)
         Tasks.await(Tasks.whenAll(zippedScouts.map { (templateId, scouts) ->
             async {
-                TemplateType.coerce(templateId)?.let {
-                    SpreadsheetExporter(scouts, notificationManager, resources.getStringArray(
-                            R.array.template_new_options)[it.id]).export()
-                } ?: run {
-                    SpreadsheetExporter(scouts, notificationManager, {
-                        templates.find { it.id == templateId }?.let {
-                            it.getTemplateName(templates.indexOf(it))
-                        } ?: getString(R.string.export_unknown_template_title)
-                    }.invoke()).export()
-                }
+                SpreadsheetExporter(scouts,
+                                    notificationManager,
+                                    templateNames[templateId]!!)
+                        .export()
+            }.addOnFailureListener {
+                abortCritical(it, notificationManager)
             }
-        }))
+        }), TIMEOUT, TimeUnit.MINUTES)
+    }
+
+    private fun getTemplateNames(templateIds: Set<String>): Map<String, String> {
+        val unknownTemplateName: String = getString(R.string.export_unknown_template_title)
+
+        val allPossibleTemplateNames: Map<String, String>
+                = Tasks.await(getTemplatesQuery().get()).associate {
+            val scout = scoutParser.parseSnapshot(it)
+            scout.id to (scout.name ?: unknownTemplateName)
+        }.toMutableMap().apply {
+            putAll(TemplateType.values().associate {
+                it.id.toString() to resources.getStringArray(R.array.template_new_options)[it.id]
+            })
+        }
+
+        val usedTemplates = HashMap<String, Int>()
+        return templateIds.associate {
+            it to (allPossibleTemplateNames[it] ?: unknownTemplateName)
+        }.mapValues { (_, name) ->
+            usedTemplates[name]?.let {
+                usedTemplates[name] = it + 1
+                "$name ($it)"
+            } ?: run {
+                usedTemplates.put(name, 1)
+                name
+            }
+        }
     }
 
     private fun zipScouts(map: Map<Team, List<Scout>>): Map<String, Map<Team, List<Scout>>> {
@@ -90,8 +115,16 @@ class ExportService : IntentService(TAG) {
         return zippedScouts
     }
 
+    private fun abortCritical(e: Exception, notificationManager: ExportNotificationManager) {
+        FirebaseCrash.report(e)
+        Crashlytics.logException(e)
+        showToast("${getString(R.string.fui_general_error)}\n\n${e.message}")
+        async { notificationManager.abort() }.logFailures()
+    }
+
     companion object {
         private const val TAG = "ExportService"
+        private const val TIMEOUT = 10L
 
         init {
             System.setProperty(

--- a/app/src/main/java/com/supercilex/robotscouter/data/client/spreadsheet/SpreadsheetExporter.kt
+++ b/app/src/main/java/com/supercilex/robotscouter/data/client/spreadsheet/SpreadsheetExporter.kt
@@ -169,13 +169,10 @@ class SpreadsheetExporter(scouts: Map<Team, List<Scout>>,
 
         var i = 1
         while (true) {
-            availableFile = when {
-                availableFile.exists() ->
-                    File(rsFolder, getFullyQualifiedFileName(templateName, " ($i)"))
-                availableFile.hide().exists() -> findAvailableFile(
-                        File(rsFolder, getFullyQualifiedFileName(templateName)),
-                        rsFolder)
-                else -> return availableFile
+            availableFile = if (availableFile.exists()) {
+                File(rsFolder, getFullyQualifiedFileName(templateName, " ($i)"))
+            } else {
+                return availableFile
             }
             i++
         }

--- a/app/src/main/java/com/supercilex/robotscouter/data/client/spreadsheet/SpreadsheetUtils.kt
+++ b/app/src/main/java/com/supercilex/robotscouter/data/client/spreadsheet/SpreadsheetUtils.kt
@@ -1,12 +1,9 @@
 package com.supercilex.robotscouter.data.client.spreadsheet
 
+import android.arch.core.executor.ArchTaskExecutor
 import android.graphics.Paint
 import android.os.Build.VERSION
 import android.os.Build.VERSION_CODES
-import android.os.Handler
-import android.os.Looper
-import com.google.firebase.crash.FirebaseCrash
-import com.supercilex.robotscouter.R
 import com.supercilex.robotscouter.RobotScouter
 import com.supercilex.robotscouter.data.model.Metric
 import com.supercilex.robotscouter.data.model.Team
@@ -139,12 +136,6 @@ fun CTTitle.setValue(text: String) {
 fun Drawing<*>.createChartAnchor(startRow: Int, startColumn: Int, endColumn: Int): ClientAnchor =
         createAnchor(0, 0, 0, 0, startColumn, startRow, endColumn, startRow + endColumn / 2)
 
-fun abortCritical(e: Exception, notificationManager: ExportNotificationManager) {
-    FirebaseCrash.report(e)
-    showToast("${RobotScouter.INSTANCE.getString(R.string.fui_general_error)}\n\n${e.message}")
-    notificationManager.abort()
-}
-
-fun showToast(message: String) = Handler(Looper.getMainLooper()).post {
+fun showToast(message: String) = ArchTaskExecutor.getInstance().executeOnMainThread {
     RobotScouter.INSTANCE.longToast(message)
 }

--- a/app/src/main/java/com/supercilex/robotscouter/util/data/model/TeamUtils.kt
+++ b/app/src/main/java/com/supercilex/robotscouter/util/data/model/TeamUtils.kt
@@ -42,7 +42,7 @@ val teamsQuery get() = "$FIRESTORE_OWNERS.${uid!!}".let {
 
 val Team.ref: DocumentReference get() = teams.document(id)
 
-fun List<Team>.getNames(): String {
+fun Collection<Team>.getNames(): String {
     val sortedTeams = ArrayList(this)
     Collections.sort(sortedTeams)
 

--- a/app/src/main/java/com/supercilex/robotscouter/util/ui/NotificationUtils.kt
+++ b/app/src/main/java/com/supercilex/robotscouter/util/ui/NotificationUtils.kt
@@ -19,19 +19,27 @@ const val EXPORT_GROUP = "export_group"
 const val EXPORT_CHANNEL = "export"
 const val EXPORT_IN_PROGRESS_CHANNEL = "export_in_progress"
 
+/**
+ * Android N+ limits notification updates to 10/sec and drops the rest. This limits notification
+ * updates to 5/sec.
+ */
+const val SAFE_NOTIFICATION_RATE_LIMIT_IN_MILLIS = 200L
+
+val notificationManager: NotificationManager by lazy {
+    RobotScouter.INSTANCE.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+}
+
 fun initNotifications() {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
 
-    RobotScouter.INSTANCE.getSystemService(NotificationManager::class.java).apply {
-        createNotificationChannelGroups(listOf(
-                NotificationChannelGroup(
-                        EXPORT_GROUP,
-                        RobotScouter.INSTANCE.getString(R.string.export_group_title))))
+    notificationManager.createNotificationChannelGroups(listOf(
+            NotificationChannelGroup(
+                    EXPORT_GROUP,
+                    RobotScouter.INSTANCE.getString(R.string.export_group_title))))
 
-        createNotificationChannels(listOf(
-                getExportChannel(),
-                getExportInProgressChannel()))
-    }
+    notificationManager.createNotificationChannels(listOf(
+            getExportChannel(),
+            getExportInProgressChannel()))
 }
 
 @RequiresApi(Build.VERSION_CODES.O)
@@ -61,7 +69,7 @@ fun getExportInProgressChannel(): NotificationChannel = NotificationChannel(
 class NotificationIntentForwarder : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        (getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager).apply {
+        notificationManager.apply {
             val notificationId = intent.getIntExtra(KEY_NOTIFICATION_ID, -1)
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -90,7 +90,7 @@
     <string name="export_overall_progress_title">Spreadsheet exporter</string>
     <string name="export_progress_title">Exporting spreadsheet</string>
 
-    <string name="export_unknown_template_title">Unknown template</string>
+    <string name="export_unknown_template_title">Unknown Template</string>
     <string name="export_offline_rationale">
         Exporting spreadsheet while offline may yield incomplete results.
     </string>


### PR DESCRIPTION
See #147

Fixes:
- Exporting would get stuck endlessly. This was caused by the `findAvailableFile` function getting stuck in a never-ending recursive loop which the kernel eventually throttled. In addition, the notification manager used flawed synchronization which could lead to the service being killed mid-export. For safety's sake, we now have a 10 min timeout at which point we kill the service.
- File names were incorrectly generated such that `[NAME]...` -> `[NAME_(1)]...` -> `[NAME_(1)]...(1)` instead of `[NAME_(2)]...`. This was fixed by removing name generation responsibilities from
`findAvailableFile` and instead moving them to the export service which has knowledge about each file being exported.
- Fixed notifications not being updated correctly. This was cause by OS rate limiting which has been fixed by filtering published notifications to ~5/sec on the client.